### PR TITLE
build: change name of RELEASE: Publish workflow

### DIFF
--- a/.github/workflows/_publish_release_for_tag.yaml
+++ b/.github/workflows/_publish_release_for_tag.yaml
@@ -1,6 +1,5 @@
 # See: https://goreleaser.com/ci/actions/#workflow
-name: "RELEASE: Publish"
-run-name: "RELEASE: Publish [${{ inputs.tag }}]"
+name: "_INC: Publish"
 
 on:
   workflow_call:


### PR DESCRIPTION
Changes the name fo the 'RELEASE: Publish' workflow, so it's more obvious in the UI that this isn't a workflow that runs against any trigger; it's just a re-usable included workflow.