### PR TITLE
build: fix issue when no release needs to be created

### DIFF
--- a/.github/workflows/create_next_release.yaml
+++ b/.github/workflows/create_next_release.yaml
@@ -36,6 +36,8 @@ jobs:
         run: npm clean-install
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
+      - name: Create empty file
+        run: echo "" > nextversion
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,6 +48,8 @@ jobs:
         run: echo "next_version=$(cat nextversion)" >> "$GITHUB_OUTPUT"
 
   publish_release:
+    # If it's empty, we don't need to create a new release
+    if: needs.generate_next_tag.outputs.next_version != ""
     name: "Publish release"
     needs:
       - generate_next_tag


### PR DESCRIPTION
Fixes an issues where if only commits that shouldn't trigger a new release were merged, the publishing job fails because of a bad ref. It fixes this by checking for an empty version, and if it's empty we skip publishing a release altogether.