### PR TITLE
docs: add docs about github actions and release process

### DIFF
--- a/docs/development_guide/github_actions.md
+++ b/docs/development_guide/github_actions.md
@@ -1,0 +1,72 @@
+# Github Actions
+
+This repository uses github actions for CI, and publishing artifacts.
+
+## Conventions
+
+The main conventions followed for github actions are outlined in this section.
+
+The name of each workflow is typically prefixed with some kind of group like `GROUP: ...`. This is just a nicety to help quickly scan through the actions when using the Github UI, as it's not always easy at a glance to know the underlying point of a workflow. For each workflow, there is usually a run-name that is almost identical the naem of the workflow but typically adds a little more info around the context in which the job is running. Typically anything that is running in the context of a PR will have `#{pr number}` to help identify it as a job for a given PR.
+
+The groups are:
+
+| Group | Purpose |
+|-------|---------|
+| **CI** | Anything thing happens to ensure that the code is in a mergeable state. |
+| **RELEASE** | Processes that take place to publish a new version of the application. |
+| **DOCS** | Processes responsible for deploying & validating documentation. |
+| **_INC** | In some cases there are workflows that are never directly triggered, but are there only to be used by other workflows. Within the repository any file that is intended to be an "includable workflow" and not triggered by any typical event, is prefixed with an `_` e.g. `_publish_release_for_tag.yaml`. |
+
+
+## Workflows
+
+This section gives a little more info on each workflow.
+
+### `commit_lint.yaml`
+
+**Must pass in order to merge**
+
+This workflow uses [commitlintjs](https://commitlint.js.org/) to verify that all the commits in the PR are following the conventional commit standards. As detailed in [Release process](./release_process.md) it is crucial to the release process that this standard is followed, and this job will fail if any commit does not conform. The `commitlint.config.js`
+file defines exactly what rules are in place.
+
+*Trigger: [pull_request](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request)*
+
+### `ci_build.yaml`
+
+**Must pass in order to merge**
+
+This runs a snapshot build of the application using goreleaser. A snaopshot is used to test that the application can be built correctly, without publishing a release anywhere. This is a basic test to ensure that code compiles.
+
+*Trigger: [pull_request](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request)*
+
+### `create_next_release.yaml`
+
+This workflow is the entrypoint of the release process, and will firstly use semantic-release to calculate what next version of the app should be. Once it has calculated this it will create a tag on the repository accordingly (although we use a `v` prefix for the tags). Once the tag has been created, it uses the [`_publish_release_for_tag.yaml`](#_publish_release_for_tagyaml) workflow which generates the release.
+
+Depending on the included commits, we may not always need a release. This logic is handled in this workflow, mostly by semantic-release, if it is determined that the commits don't require a new release, then there will be no new tag or release created.
+
+Their is a concurrency rule on this workflow that prevents it running in parallel for more than one commit on the branch; this is to ensure that the versions are incremented correctly. Due to the way semantic-release works (it fetches tags to calculate the next), it could be very unpredictable if multiple instances were to run at the same time.
+
+*Trigger: [push](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#push) on main*
+
+### `_publish_release_for_tag.yaml`
+
+| Input | Required | Detail |
+|-------|----------|--------|
+| `tag` | Yes | This specifies the tag that a release should be created for. |
+
+This workflow is used by [`create_next_release.yaml`](#create_next_releaseyaml), once it knows the version to create. It will pass the new tag into this workflow, and run goreleaser to generate a new release in Github. Goreleaser attaches the executables for various architectures to the release for distribution. 
+
+*Trigger: [workflow_call](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call)*
+
+### `deploy_github_pages.yaml`
+
+This workflow renders and publishes the documentation using mkdocs. It pushes the rendered files to the `gh-pages` branch in this repo, and from there github pages will take over and deploy the contents of `gh-pages` branch.
+
+*Trigger: [push](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#push) on main, but only if it includes changes to documentation*
+
+
+### [Github managed] `pages-build-deployment`
+
+This workflow isn't contained within the repository, but is managed by Github when we enable the github pages deployment. It will run whenever the `gh-pages` branch is updated.
+

--- a/docs/development_guide/index.md
+++ b/docs/development_guide/index.md
@@ -1,4 +1,4 @@
-# Contributing guidelines
+# Development guide
 
 This repository uses [Github Flow](https://docs.github.com/en/get-started/using-github/github-flow) branching strategy; feature branches come off of main, should be short-lived, and then are merged back into main. The configuration of the repository is configured to allow only squash merging, to keep the commit history clean and informative. To aid this it is following the [conventional commit standard](https://www.conventionalcommits.org/en/v1.0.0/), which is enforced via a CI check.
 
@@ -19,3 +19,7 @@ The usage of some of the features in mkdocs will result in the docs not renderin
 ### Working locally
 
 If you're writing docs locally and wanna see what the rendered result looks like you can use the mkdocs server in watch mode. This is all hooked up in the `docker-compose.yml` file. Simply run `make dc-up` in the root of this repository, and you'll be able to see the rendered docs on [http://localhost:9898](http://localhost:9898). Every time either the `mkdocs.yml` config or a file in the `docs` directory changes, it will be re-rendered and any browsers will reload the page.
+
+## Why npm?
+
+NPM isn't actually used by the app in any way, but a couple of the tools we're using require it. We need to install some plugins for [semantic-release](https://semantic-release.gitbook.io/semantic-release/) and [commitlintjs](https://commitlint.js.org/), so we have an npm file structure to enable these tools.

--- a/docs/development_guide/release_process.md
+++ b/docs/development_guide/release_process.md
@@ -1,0 +1,32 @@
+# Release process
+
+The release process is fully automated for this project. It's centered around conventional commits and semantic versioning. We use a couple of tools to help with this:
+
+- [semantic-release](https://semantic-release.gitbook.io/semantic-release/)
+- [Goreleaser](https://goreleaser.com/)
+
+The full process for shipping a new version of the application is shown below. The main thing to remember is that we must use conventional commits correctly, as the `type` of the commit largely determines the next version for release. For example, if we create a `fix` commit then the patch version will be incremented, however if we use a `feat` commit then the minor version will be incremented.
+
+*See [Github Actions](./github_actions.md) for more info on the exact steps.*
+
+??? tip "Workflow"
+    ```mermaid
+    flowchart TD
+        A([Dev]) -->|Creates feature branch| B(Makes changes)
+        B --> |Creates PR| C{Quality checks}
+        C -->|Approved & CI Passed| D[Merges PR to main]
+        C -->|Changes Requested OR CI Failed| B
+        D -->|Release process starts| E[semantic-release: Calculates next version based on Conventional Commits]
+        E -->|Result| F{Requires release}
+        F -->|Yes| G[New Tag created]
+        F -->|No| H([No release created])
+        G --> I([Goreleaser: publishes new release for tag])
+    ```
+
+## semantic-release
+
+The semantic release configuration can be found in `.releaserc`, and it's pretty minimal. The current configuration is setup to only create a tag in the git repo, and not to create a github release or changelog etc. This is by design, so that we can rely on goreleaser to generate a new release that includes the artifacts for downloading the executable.
+
+## goreleaser
+
+The goreleaser configuration is found in `.goreleaser.yaml`, and is mostly boilerplate. There are a few minor changes to tell it where to find the entrypoint of the application code, and make the release notes a little more organised.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,11 @@ use_directory_urls: true
 markdown_extensions:
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.highlight:


### PR DESCRIPTION
Adds docs to cover off how github actions is setup and a brief explanation of each of the workflows.

Adds docs to explain how the release process is setup, and which tools are used to manage it.