### PR TITLE
build: update release notes format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,8 +47,8 @@ changelog:
     - title: Features
       regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
       order: 0
-    - title: "Bug fixes"
-      regexp: '^.*?bug(\([[:word:]]+\))??!?:.+$'
+    - title: "Fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
       order: 1
     - title: Everything else
       order: 999
@@ -57,3 +57,4 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+      - "^build:"


### PR DESCRIPTION
Excludes the `build` prefix from release notes, and uses the correct pattern for matching fixes.