### PR TITLE
docs: add coverage badge to readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Orca
 
+![coverage](https://raw.githubusercontent.com/panoptescloud/orca/badges/.badges/main/coverage.svg)
+
+
 Documentation is found on Github pages: [https://panoptescloud.github.io/orca/](https://panoptescloud.github.io/orca/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+![coverage](https://raw.githubusercontent.com/panoptescloud/orca/badges/.badges/main/coverage.svg)
+
 # Home
 
 Whalecome!


### PR DESCRIPTION
Adds the coverage badge to the docs and to the README for the repository.