### PR TITLE
docs: add a trivy scan badge

### DIFF
--- a/.github/workflows/nightly_scan.yaml
+++ b/.github/workflows/nightly_scan.yaml
@@ -1,10 +1,10 @@
 # See: https://commitlint.js.org/guides/ci-setup.html
-name: "SECURITY: Scan repo (main branch)"
-run-name: "SECURITY: Scan repo (main branch)"
+name: "SECURITY: Scan"
+run-name: "SECURITY: Scan ${{ github.ref }}"
 
 on:
   schedule:
-    - cron: "15 4,5 * * *"
+    - cron: "0 23 * * *"
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Orca
 
 ![coverage](https://raw.githubusercontent.com/panoptescloud/orca/badges/.badges/main/coverage.svg)
+[![Trivy Scan](https://github.com/panoptescloud/orca/actions/workflows/nightly_scan.yaml/badge.svg?label=Blah)](https://github.com/panoptescloud/orca/actions/workflows/nightly_scan.yaml)
 
 
 Documentation is found on Github pages: [https://panoptescloud.github.io/orca/](https://panoptescloud.github.io/orca/)


### PR DESCRIPTION
Adds a badge to the readme showing the status of the latest trivy scan for the main branch.