### PR TITLE
ci: add a trivy scan for executables

### DIFF
--- a/.github/workflows/ci_build.yaml
+++ b/.github/workflows/ci_build.yaml
@@ -29,3 +29,15 @@ jobs:
           args: build --clean --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # I'm not 100% sure this is actually doing anything. I don't think there are
+      # any vulnerabilities (even when testing locally) but it's hard to be sure
+      # that it's scanning them properly. Take this with a pinch of salt is all
+      # I'm saying.:
+      - name: Run Trivy vulnerability scanner in fs mode
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'fs'
+          scan-ref: './dist'
+          trivy-config: trivy.yaml
+          # Make trivy fail when it finds a vulnerability
+          exit-code: 1


### PR DESCRIPTION
Adds a trivy scan to the CI: Build job, so that it scans the actual executables we produce.