### PR TITLE
feat(compose): add env file option + show compose command

### DIFF
--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -27,7 +27,13 @@ jobs:
           export PATH=$PATH:$GOPATH/bin
           go install github.com/jstemmer/go-junit-report@latest
       - name: Run tests
-        run: go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
+        # Set is the default covermode, when using atomic as suggested in the docs 
+        # for the test coverage action, we get some weird bugs. I think the bugs
+        # are within the test-coverage action below. Right now we don't need to
+        # test any parallel algorihms, which is basically thge obly use-case for
+        # the atomic covermode, so stick with the default.
+        # See: https://go.dev/blog/cover#heat-maps
+        run: go test ./... -coverprofile=./cover.out -covermode=set -coverpkg=./...
       - name: check test coverage
         uses: vladopajic/go-test-coverage@v2
         if: always()

--- a/.github/workflows/generate_badges.yaml
+++ b/.github/workflows/generate_badges.yaml
@@ -30,7 +30,7 @@ jobs:
           export PATH=$PATH:$GOPATH/bin
           go install github.com/jstemmer/go-junit-report@latest
       - name: Run tests
-        run: go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
+        run: go test ./... -coverprofile=./cover.out -covermode=set -coverpkg=./...
       - name: check test coverage
         uses: vladopajic/go-test-coverage@v2
         if: always()

--- a/cmd/orca/debug.go
+++ b/cmd/orca/debug.go
@@ -18,3 +18,17 @@ func handleDebugShowComposeConfig(cmd *cobra.Command, args []string) error {
 		Project:   project,
 	})
 }
+
+func handleDebugShowComposeCommand(cmd *cobra.Command, args []string) error {
+	ctrl := svcContainer.GetController()
+
+	ws, err := cmd.Flags().GetString("workspace")
+	cobra.CheckErr(err)
+	project, err := cmd.Flags().GetString("project")
+	cobra.CheckErr(err)
+
+	return ctrl.ShowComposeCommand(controller.ShowComposeCommandDTO{
+		Workspace: ws,
+		Project:   project,
+	})
+}

--- a/cmd/orca/main.go
+++ b/cmd/orca/main.go
@@ -254,6 +254,13 @@ including any relevant values from environment variables, or profile changes etc
 	Run: errorHandlerWrapper(handleDebugShowComposeConfig, 1),
 }
 
+var debugShowComposeCommandCmd = &cobra.Command{
+	Use:   "show-compose-command",
+	Short: `Shows the compose command being used for this project.`,
+	Long:  `Can be used to run generic commands via: ` + "`$(orca debug show-compose-command) ps`",
+	Run:   errorHandlerWrapper(handleDebugShowComposeCommand, 1),
+}
+
 var logsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: `Tails logs from docker compose project.`,
@@ -453,6 +460,10 @@ If a single project is being clone then it will be cloned into {target}.`)
 	addWorkspaceOption(debugShowComposeConfigCmd, false)
 	addProjectOption(debugShowComposeConfigCmd)
 	debugCmd.AddCommand(debugShowComposeConfigCmd)
+
+	addWorkspaceOption(debugShowComposeCommandCmd, false)
+	addProjectOption(debugShowComposeCommandCmd)
+	debugCmd.AddCommand(debugShowComposeCommandCmd)
 	rootCmd.AddCommand(debugCmd)
 
 	// exec

--- a/internal/common/workspace.go
+++ b/internal/common/workspace.go
@@ -40,8 +40,13 @@ type Extension struct {
 	Service string
 }
 
+type EnvFile struct {
+	Path string
+}
+
 type ProjectConfig struct {
 	ComposeFiles    ComposeFiles
+	EnvFiles        []EnvFile
 	Properties      []Property
 	Hosts           []string
 	TLSCertificates []string
@@ -76,6 +81,15 @@ func (p Project) GetParents() []string {
 
 func (p Project) GetChildren() []string {
 	return []string{}
+}
+
+func (p Project) EnvFilePaths() []string {
+	paths := make([]string, len(p.Config.EnvFiles))
+	for i, e := range p.Config.EnvFiles {
+		paths[i] = e.Path
+	}
+
+	return paths
 }
 
 type NetworkOverlayConfig struct {

--- a/internal/controller/main.go
+++ b/internal/controller/main.go
@@ -28,7 +28,8 @@ type workspaceRepository interface {
 type compose interface {
 	Up(*common.Workspace, *common.Project) error
 	Down(ws *common.Workspace, p *common.Project) error
-	Show(ws *common.Workspace, p *common.Project) error
+	ShowConfig(ws *common.Workspace, p *common.Project) error
+	ShowCommand(ws *common.Workspace, p *common.Project) error
 	Exec(ws *common.Workspace, p *common.Project, service string, cmdArgs []string) error
 	Logs(ws *common.Workspace, p *common.Project, service string) error
 }

--- a/internal/controller/show_compose_command.go
+++ b/internal/controller/show_compose_command.go
@@ -2,12 +2,12 @@ package controller
 
 import "github.com/panoptescloud/orca/internal/common"
 
-type ShowComposeConfigDTO struct {
+type ShowComposeCommandDTO struct {
 	Workspace string
 	Project   string
 }
 
-func (c *Controller) ShowComposeConfig(dto ShowComposeConfigDTO) error {
+func (c *Controller) ShowComposeCommand(dto ShowComposeCommandDTO) error {
 	ctx, err := c.resolveContext(dto.Workspace, dto.Project)
 
 	if err != nil {
@@ -20,5 +20,5 @@ func (c *Controller) ShowComposeConfig(dto ShowComposeConfigDTO) error {
 		}
 	}
 
-	return c.compose.ShowConfig(ctx.Workspace, ctx.Project)
+	return c.compose.ShowCommand(ctx.Workspace, ctx.Project)
 }

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -34,7 +34,13 @@ func (c *Compose) getOverlay(ws *common.Workspace, p *common.Project) (string, e
 }
 
 func buildBaseComposeCommand(ws *common.Workspace, p *common.Project, overlayPath string) []string {
-	return []string{
+	envArgs := []string{}
+
+	for _, e := range p.Config.EnvFiles {
+		envArgs = append(envArgs, "--env-file", e.Path)
+	}
+
+	args := []string{
 		"docker",
 		"compose",
 		"-f",
@@ -44,6 +50,10 @@ func buildBaseComposeCommand(ws *common.Workspace, p *common.Project, overlayPat
 		"-p",
 		fmt.Sprintf("orca-%s-%s", ws.Name, p.Name),
 	}
+
+	args = append(args, envArgs...)
+
+	return args
 }
 
 func NewCompose(cli cli, tui tui, overlayGenerator composeOverlayGenerator) *Compose {

--- a/internal/docker/compose_parser.go
+++ b/internal/docker/compose_parser.go
@@ -10,12 +10,17 @@ import (
 type ComposeParser struct {
 }
 
-func (cp *ComposeParser) Parse(paths []string) (*types.Project, error) {
+func (cp *ComposeParser) Parse(paths []string, envFiles []string) (*types.Project, error) {
 	opts, err := composecli.NewProjectOptions(
 		paths,
+		composecli.WithEnvFiles(envFiles...),
 	)
 
 	if err != nil {
+		return nil, err
+	}
+
+	if err := composecli.WithDotEnv(opts); err != nil {
 		return nil, err
 	}
 

--- a/internal/docker/compose_show_command.go
+++ b/internal/docker/compose_show_command.go
@@ -1,0 +1,21 @@
+package docker
+
+import (
+	"strings"
+
+	"github.com/panoptescloud/orca/internal/common"
+)
+
+// TODO: guard against nil inputs
+func (c *Compose) ShowCommand(ws *common.Workspace, p *common.Project) error {
+	overlay, err := c.getOverlay(ws, p)
+	if err != nil {
+		return c.tui.RecordIfError("Failed to generate overlays!", err)
+	}
+
+	cmd := buildBaseComposeCommand(ws, p, overlay)
+
+	c.tui.Info(strings.Join(cmd, " "))
+
+	return nil
+}

--- a/internal/docker/compose_show_config.go
+++ b/internal/docker/compose_show_config.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TODO: guard against nil inputs
-func (c *Compose) Show(ws *common.Workspace, p *common.Project) error {
+func (c *Compose) ShowConfig(ws *common.Workspace, p *common.Project) error {
 	overlay, err := c.getOverlay(ws, p)
 	if err != nil {
 		return c.tui.RecordIfError("Failed to generate overlays!", err)

--- a/internal/docker/overlays.go
+++ b/internal/docker/overlays.go
@@ -132,7 +132,7 @@ func (ogc *overlayGenerationContext) AddServiceNetworkConfig() error {
 }
 
 type overlayComposeParser interface {
-	Parse(paths []string) (*types.Project, error)
+	Parse(paths []string, envFiles []string) (*types.Project, error)
 }
 
 type ComposeOverlayGenerator struct {
@@ -223,9 +223,13 @@ func (cog *ComposeOverlayGenerator) buildOverlay(ctx *overlayGenerationContext) 
 }
 
 func (cog *ComposeOverlayGenerator) CreateOrRetrieve(ws *common.Workspace, p *common.Project) (string, error) {
-	composeProject, err := cog.parser.Parse([]string{
-		fmt.Sprintf("%s/%s", p.ProjectDir, p.Config.ComposeFiles.Primary),
-	})
+	composeProject, err := cog.parser.Parse(
+		[]string{
+			fmt.Sprintf("%s/%s", p.ProjectDir, p.Config.ComposeFiles.Primary),
+		},
+		p.EnvFilePaths(),
+	)
+
 	if err != nil {
 		return "", err
 	}

--- a/internal/repository/internal/model/project.go
+++ b/internal/repository/internal/model/project.go
@@ -34,8 +34,13 @@ type Extension struct {
 	Service string
 }
 
+type EnvFile struct {
+	Path string
+}
+
 type ProjectConfig struct {
 	ComposeFiles    ComposeFiles `yaml:"composeFiles"`
+	EnvFiles        []EnvFile    `yaml:"envFiles"`
 	Properties      []Property
 	Hosts           []string
 	TLSCertificates []string `yaml:"tlsCerts"`

--- a/internal/repository/workspaces.go
+++ b/internal/repository/workspaces.go
@@ -96,6 +96,22 @@ func convertExtensions(cfgExts []model.Extension) []common.Extension {
 	return exts
 }
 
+func convertEnvFile(e model.EnvFile) common.EnvFile {
+	return common.EnvFile{
+		Path: e.Path,
+	}
+}
+
+func convertEnvFiles(cfgEnvFiles []model.EnvFile) []common.EnvFile {
+	envFiles := make([]common.EnvFile, len(cfgEnvFiles))
+
+	for i, e := range cfgEnvFiles {
+		envFiles[i] = convertEnvFile(e)
+	}
+
+	return envFiles
+}
+
 func buildProject(wsPCfg model.WorkspaceProjectConfig, meta common.ProjectMeta, pCfg model.ProjectConfig) common.Project {
 	return common.Project{
 		Name: wsPCfg.Name,
@@ -112,6 +128,7 @@ func buildProject(wsPCfg model.WorkspaceProjectConfig, meta common.ProjectMeta, 
 			Hosts:           pCfg.Hosts,
 			TLSCertificates: pCfg.TLSCertificates,
 			Extensions:      convertExtensions(pCfg.Extensions),
+			EnvFiles:        convertEnvFiles(pCfg.EnvFiles),
 		},
 	}
 }


### PR DESCRIPTION
Adds support for defining dotenv files in the project config. These are passed to subsequent docker compose commands. These are also passed to the compose-go parser when generating overlays to ensure they are all correctly resolved.

Adds a 'debug show-compose-command' command to show the actual docker compose command being used.