### PR TITLE
fix: run docker compose commands from correct directory

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/panoptescloud/orca/internal/common"
 	"github.com/panoptescloud/orca/internal/hostsys"
@@ -31,6 +32,11 @@ type Compose struct {
 
 func (c *Compose) getOverlay(ws *common.Workspace, p *common.Project) (string, error) {
 	return c.overlayGenerator.CreateOrRetrieve(ws, p)
+}
+
+// TODO: gaurd against nil values
+func (c *Compose) goToProject(p *common.Project) error {
+	return os.Chdir(p.ProjectDir)
 }
 
 func buildBaseComposeCommand(ws *common.Workspace, p *common.Project, overlayPath string) []string {

--- a/internal/docker/compose_down.go
+++ b/internal/docker/compose_down.go
@@ -9,6 +9,10 @@ import (
 
 // TODO: guard against nil arguments
 func (c *Compose) Down(ws *common.Workspace, p *common.Project) error {
+	if err := c.goToProject(p); err != nil {
+		return err
+	}
+
 	overlay, err := c.getOverlay(ws, p)
 	if err != nil {
 		return c.tui.RecordIfError("Failed to generate overlays!", err)

--- a/internal/docker/compose_exec.go
+++ b/internal/docker/compose_exec.go
@@ -9,6 +9,10 @@ import (
 
 // TODO: guard against nil inputs
 func (c *Compose) Exec(ws *common.Workspace, p *common.Project, service string, cmdArgs []string) error {
+	if err := c.goToProject(p); err != nil {
+		return err
+	}
+
 	overlay, err := c.getOverlay(ws, p)
 	if err != nil {
 		return c.tui.RecordIfError("Failed to generate overlays!", err)

--- a/internal/docker/compose_logs.go
+++ b/internal/docker/compose_logs.go
@@ -7,6 +7,10 @@ import (
 
 // TODO: guard against nil arguments
 func (c *Compose) Logs(ws *common.Workspace, p *common.Project, service string) error {
+	if err := c.goToProject(p); err != nil {
+		return err
+	}
+
 	overlay, err := c.getOverlay(ws, p)
 	if err != nil {
 		return c.tui.RecordIfError("Failed to generate overlays!", err)

--- a/internal/docker/compose_show_command.go
+++ b/internal/docker/compose_show_command.go
@@ -8,6 +8,10 @@ import (
 
 // TODO: guard against nil inputs
 func (c *Compose) ShowCommand(ws *common.Workspace, p *common.Project) error {
+	if err := c.goToProject(p); err != nil {
+		return err
+	}
+
 	overlay, err := c.getOverlay(ws, p)
 	if err != nil {
 		return c.tui.RecordIfError("Failed to generate overlays!", err)

--- a/internal/docker/compose_show_config.go
+++ b/internal/docker/compose_show_config.go
@@ -9,6 +9,10 @@ import (
 
 // TODO: guard against nil inputs
 func (c *Compose) ShowConfig(ws *common.Workspace, p *common.Project) error {
+	if err := c.goToProject(p); err != nil {
+		return err
+	}
+
 	overlay, err := c.getOverlay(ws, p)
 	if err != nil {
 		return c.tui.RecordIfError("Failed to generate overlays!", err)

--- a/internal/docker/compose_up.go
+++ b/internal/docker/compose_up.go
@@ -9,6 +9,10 @@ import (
 
 // TODO: guard against nil arguments
 func (c *Compose) Up(ws *common.Workspace, p *common.Project) error {
+	if err := c.goToProject(p); err != nil {
+		return err
+	}
+
 	overlay, err := c.getOverlay(ws, p)
 	if err != nil {
 		return c.tui.RecordIfError("Failed to generate overlays!", err)


### PR DESCRIPTION
Fixes an issue when running a docker compose command from outside the project directory, where the overlays and env files are not properly included. This was most notable when running up or down for an entire project as the overlays didn't render properly and gave a warning. The fix is to actually change the working directory to each project when running any commands for it; it will not change the actual working dir for the user in the terminal.