### PR TITLE
feat: add ext command

### DIFF
--- a/cmd/orca/ext.go
+++ b/cmd/orca/ext.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/panoptescloud/orca/internal/controller"
+	"github.com/spf13/cobra"
+)
+
+func handleExt(cmd *cobra.Command, args []string) error {
+	ctrl := svcContainer.GetController()
+
+	ws, err := cmd.Flags().GetString("workspace")
+	cobra.CheckErr(err)
+	project, err := cmd.Flags().GetString("project")
+	cobra.CheckErr(err)
+
+	// TODO: validate arguments provided
+	extensionName := args[0]
+	extensionArgs := args[1:]
+
+	return ctrl.ExecuteExtension(controller.ExecuteExtensionDTO{
+		Workspace: ws,
+		Project:   project,
+		Name:      extensionName,
+		Args:      extensionArgs,
+	})
+}

--- a/cmd/orca/main.go
+++ b/cmd/orca/main.go
@@ -274,6 +274,12 @@ var hostsCmd = &cobra.Command{
 	Run:   errorHandlerWrapper(handleHosts, 1),
 }
 
+var extCmd = &cobra.Command{
+	Use:   "ext",
+	Short: "Execute a custom extension, defined in the project configuration",
+	Run:   errorHandlerWrapper(handleExt, 1),
+}
+
 func errorHandlerWrapper(f runEHandlerFunc, errorExitCode int) runHandlerFunc {
 	return func(cmd *cobra.Command, args []string) {
 		err := f(cmd, args)
@@ -481,6 +487,11 @@ If a single project is being clone then it will be cloned into {target}.`)
 	// hosts
 	addWorkspaceOption(hostsCmd, true)
 	rootCmd.AddCommand(hostsCmd)
+
+	// ext
+	addWorkspaceOption(extCmd, false)
+	addProjectOption(extCmd)
+	rootCmd.AddCommand(extCmd)
 }
 
 func addServiceOption(cmd *cobra.Command, required bool) {

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -262,3 +262,11 @@ func (err ErrInvalidValueForOverlayModifier) Error() string {
 
 	return fmt.Sprintf("invalid value for label '%s' modifier in compose file %s: %s", err.Label, svc, err.Message)
 }
+
+type ErrUnknownExtension struct {
+	Name string
+}
+
+func (err ErrUnknownExtension) Error() string {
+	return fmt.Sprintf("extension '%s' not found in project", err.Name)
+}

--- a/internal/common/workspace.go
+++ b/internal/common/workspace.go
@@ -34,10 +34,11 @@ type Property struct {
 }
 
 type Extension struct {
-	Name    string
-	Chdir   string
-	Command string
-	Service string
+	Name        string
+	Chdir       string
+	Command     string
+	Service     string
+	DefaultArgs []string
 }
 
 type EnvFile struct {
@@ -90,6 +91,18 @@ func (p Project) EnvFilePaths() []string {
 	}
 
 	return paths
+}
+
+func (p Project) FindExtension(name string) (Extension, error) {
+	for _, ext := range p.Config.Extensions {
+		if ext.Name == name {
+			return ext, nil
+		}
+	}
+
+	return Extension{}, ErrUnknownExtension{
+		Name: name,
+	}
 }
 
 type NetworkOverlayConfig struct {

--- a/internal/controller/ext.go
+++ b/internal/controller/ext.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/panoptescloud/orca/internal/common"
+)
+
+type ExecuteExtensionDTO struct {
+	Workspace string
+	Project   string
+	Name      string
+	Args      []string
+}
+
+func (c *Controller) executeExtensionInService(dto ExecuteExtensionDTO, ctx runtimeContext, ext common.Extension) error {
+	cmdArgs := strings.Split(ext.Command, " ")
+
+	if len(dto.Args) > 0 {
+		cmdArgs = append(cmdArgs, dto.Args...)
+	} else {
+		cmdArgs = append(cmdArgs, ext.DefaultArgs...)
+	}
+
+	c.compose.Exec(
+		ctx.Workspace,
+		ctx.Project,
+		ext.Service,
+		cmdArgs,
+	)
+
+	return nil
+}
+
+func (c *Controller) ExecuteExtension(dto ExecuteExtensionDTO) error {
+	ctx, err := c.resolveContext(dto.Workspace, dto.Project)
+
+	if err != nil {
+		return err
+	}
+
+	if ctx.Project == nil {
+		return common.ErrInvalidExecutionContext{
+			Msg: "Extensions must be executed within a project context!",
+		}
+	}
+
+	ext, err := ctx.Project.FindExtension(dto.Name)
+
+	if err != nil {
+		return c.tui.RecordIfError("Extension does not exist in project context.", err)
+	}
+
+	if ext.Service != "" {
+		return c.executeExtensionInService(dto, ctx, ext)
+	}
+
+	return c.tui.RecordIfError("Extension must have a service defined", errors.New("alternative is not yet implemented"))
+}

--- a/internal/repository/internal/model/project.go
+++ b/internal/repository/internal/model/project.go
@@ -28,10 +28,11 @@ type Property struct {
 }
 
 type Extension struct {
-	Name    string
-	Chdir   string
-	Command string
-	Service string
+	Name        string
+	Chdir       string
+	Command     string
+	Service     string
+	DefaultArgs []string `yaml:"defaultArgs"`
 }
 
 type EnvFile struct {

--- a/internal/repository/workspaces.go
+++ b/internal/repository/workspaces.go
@@ -79,10 +79,11 @@ func convertProperties(cfgProps []model.Property) []common.Property {
 
 func convertExtension(e model.Extension) common.Extension {
 	return common.Extension{
-		Name:    e.Name,
-		Chdir:   e.Chdir,
-		Command: e.Command,
-		Service: e.Service,
+		Name:        e.Name,
+		Chdir:       e.Chdir,
+		Command:     e.Command,
+		Service:     e.Service,
+		DefaultArgs: e.DefaultArgs,
 	}
 }
 


### PR DESCRIPTION
Adds an 'ext' command allowing the user to define common scripts to run for each project in the project configuration file. These can be executed by running 'orca ext {name} {?args}' from within the projects context.

Currently only supports running scripts from within one of the projects docker compose services, rather than directly on the host.