### PR TITLE
feat: support exec or ext in non-running containers

### DIFF
--- a/cmd/orca/exec.go
+++ b/cmd/orca/exec.go
@@ -15,7 +15,7 @@ func handleExec(cmd *cobra.Command, args []string) error {
 	service, err := cmd.Flags().GetString("service")
 	cobra.CheckErr(err)
 
-	return ctrl.Exec(controller.ExecDTO{
+	return ctrl.ExecOrRun(controller.ExecDTO{
 		Workspace: ws,
 		Project:   project,
 		Service:   service,

--- a/internal/controller/exec_or_run.go
+++ b/internal/controller/exec_or_run.go
@@ -7,11 +7,21 @@ type ExecDTO struct {
 	Args      []string
 }
 
-func (c *Controller) Exec(dto ExecDTO) error {
+func (c *Controller) ExecOrRun(dto ExecDTO) error {
 	ctx, err := c.resolveContext(dto.Workspace, dto.Project)
 
 	if err != nil {
 		return err
+	}
+
+	isRunning, err := c.compose.IsSvcRunning(ctx.Workspace, ctx.Project, dto.Service)
+
+	if err != nil {
+		return err
+	}
+
+	if !isRunning {
+		return c.compose.Run(ctx.Workspace, ctx.Project, dto.Service, dto.Args)
 	}
 
 	return c.compose.Exec(ctx.Workspace, ctx.Project, dto.Service, dto.Args)

--- a/internal/controller/main.go
+++ b/internal/controller/main.go
@@ -32,6 +32,8 @@ type compose interface {
 	ShowCommand(ws *common.Workspace, p *common.Project) error
 	Exec(ws *common.Workspace, p *common.Project, service string, cmdArgs []string) error
 	Logs(ws *common.Workspace, p *common.Project, service string) error
+	IsSvcRunning(ws *common.Workspace, p *common.Project, service string) (bool, error)
+	Run(ws *common.Workspace, p *common.Project, service string, cmdArgs []string) error
 }
 
 type Controller struct {

--- a/internal/docker/compose_is_svc_running.go
+++ b/internal/docker/compose_is_svc_running.go
@@ -1,0 +1,54 @@
+package docker
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/panoptescloud/orca/internal/common"
+	"github.com/panoptescloud/orca/internal/hostsys"
+)
+
+// TODO: guard against nil arguments
+func (c *Compose) IsSvcRunning(ws *common.Workspace, p *common.Project, service string) (bool, error) {
+	if err := c.goToProject(p); err != nil {
+		return false, err
+	}
+
+	overlay, err := c.getOverlay(ws, p)
+	if err != nil {
+		return false, c.tui.RecordIfError("Failed to generate overlays!", err)
+	}
+
+	baseCmd := buildBaseComposeCommand(ws, p, overlay)
+	psCmd := append(baseCmd, "ps", "-q", service)
+
+	withStdout, outBuff := hostsys.WithStdout()
+	withStderr, errBuff := hostsys.WithStderr()
+
+	err = c.cli.Exec(psCmd[0], psCmd[1:], withStdout, withStderr, hostsys.ChdirOpt(p.ProjectDir))
+
+	if err != nil {
+		slog.Debug("stderr from docker compose ps", "stderr", errBuff.String())
+		return false, c.tui.RecordIfError("Failed to check if pod is running", err)
+	}
+
+	containerID := strings.TrimSpace(outBuff.String())
+	if containerID == "" {
+		// Service not found or not running at all
+		return false, nil
+	}
+
+	withStdout, outBuff = hostsys.WithStdout()
+	withStderr, errBuff = hostsys.WithStderr()
+
+	err = c.cli.Exec("docker", []string{"inspect", "-f", "{{.State.Running}}", containerID}, withStdout, withStderr)
+
+	if err != nil {
+		slog.Debug("stderr from docker inspect", "stderr", errBuff.String())
+		return false, c.tui.RecordIfError("Failed to inspect pod", err)
+	}
+
+	state := strings.TrimSpace(outBuff.String())
+
+	return state == "true", nil
+}

--- a/internal/docker/compose_parser.go
+++ b/internal/docker/compose_parser.go
@@ -14,6 +14,11 @@ func (cp *ComposeParser) Parse(paths []string, envFiles []string) (*types.Projec
 	opts, err := composecli.NewProjectOptions(
 		paths,
 		composecli.WithEnvFiles(envFiles...),
+		// Pass all profiles when generating overlays. If not certain services may
+		// be skipped, but we still want them in the overlay. This is mostly to
+		// handle scenarios for one-off commands, that may not be running at all
+		// unless manually invoked.
+		composecli.WithProfiles([]string{"*"}),
 	)
 
 	if err != nil {

--- a/internal/docker/compose_run.go
+++ b/internal/docker/compose_run.go
@@ -1,0 +1,39 @@
+package docker
+
+import (
+	"os/exec"
+
+	"github.com/panoptescloud/orca/internal/common"
+	"github.com/panoptescloud/orca/internal/hostsys"
+)
+
+// TODO: guard against nil inputs
+func (c *Compose) Run(ws *common.Workspace, p *common.Project, service string, cmdArgs []string) error {
+	if err := c.goToProject(p); err != nil {
+		return err
+	}
+
+	overlay, err := c.getOverlay(ws, p)
+	if err != nil {
+		return c.tui.RecordIfError("Failed to generate overlays!", err)
+	}
+
+	cmd := buildBaseComposeCommand(ws, p, overlay)
+	cmd = append(cmd, "run", "-it", "--rm", service)
+	cmd = append(cmd, cmdArgs...)
+
+	err = c.cli.Exec(cmd[0], cmd[1:], hostsys.WithHostIO(), hostsys.ChdirOpt(p.ProjectDir))
+
+	if err != nil {
+		// If it's exit code 130, it's because they exited an interactive container
+		// typically. Not sure if this is always true though, need to see how this
+		// works across more use-cases.
+		if exitError, ok := err.(*exec.ExitError); ok && exitError.ProcessState.ExitCode() == 130 {
+			return nil
+		}
+
+		return c.tui.RecordIfError("Command failed!", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds support for running commands inside a service that isn't actually running. This is useful for helper scripts like migrations that only need to run occasionally, and at manual request. This supports this by checking if the service is running and using the run command instead of the exec command if it isn't.

Also addressed an issue with the networking when a profile isn't supplied. When generating the overlays any services that weren't enabled due to a profile not being supplied, didn't get the relevant networking config. This fixes that by enabling all profiles when generating the overlays.