### PR TITLE
build: update semanticrelease script

### DIFF
--- a/scripts/semanticrelease.sh
+++ b/scripts/semanticrelease.sh
@@ -3,4 +3,5 @@
 
 npx --yes --package semantic-release@25 \
     --package conventional-changelog-conventionalcommits@9 \
+    --package @semantic-release/exec@7 \
     semantic-release "$@"


### PR DESCRIPTION
There was a package missing from the semanticrelease npx command that was breaking the release process. This should fix it by including the exec plugin.